### PR TITLE
csearch pulls regexp from github

### DIFF
--- a/cmd/csearch/csearch.go
+++ b/cmd/csearch/csearch.go
@@ -12,7 +12,7 @@ import (
 	"runtime/pprof"
 
 	"github.com/google/codesearch/index"
-	"code.google.com/p/codesearch/regexp"
+	"github.com/google/codesearch/regexp"
 )
 
 var usageMessage = `usage: csearch [-c] [-f fileregexp] [-h] [-i] [-l] [-n] regexp


### PR DESCRIPTION
go get was failing with
```
package code.google.com/p/codesearch/regexp: unable to detect version control
system for code.google.com/ path
```
now it just pulls from github directly.