### PR TITLE
Fix race condition

### DIFF
--- a/index/write.go
+++ b/index/write.go
@@ -599,10 +599,11 @@ func validUTF8(c1, c2 uint32) bool {
 // 24 bits to sort.  Run two rounds of 12-bit radix sort.
 const sortK = 12
 
-var sortTmp []postEntry
-var sortN [1 << sortK]int
 
 func sortPost(post []postEntry) {
+	var sortTmp []postEntry
+	var sortN [1 << sortK]int
+
 	if len(post) > len(sortTmp) {
 		sortTmp = make([]postEntry, len(post))
 	}


### PR DESCRIPTION
When multiple IndexWriter instances call Flush concurrently, they hit race or index out of range for `sortTmp` since it's getting modified from multiple go routines. 
example: 
```
goroutine 59 [running]:
github.com/meerkat/vendor/github.com/google/codesearch/index.sortPost(0xc023ab0000, 0x32f2, 0x800000)
	/Users/behrooz/go/src/github.com/meerkat/vendor/github.com/google/codesearch/index/write.go:648 +0x298
github.com/meerkat/vendor/github.com/google/codesearch/index.(*IndexWriter).mergePost(0xc0000d62c0, 0xc001e8e300)
	/Users/behrooz/go/src/github.com/meerkat/vendor/github.com/google/codesearch/index/write.go:291 +0x13c
github.com/meerkat/vendor/github.com/google/codesearch/index.(*IndexWriter).Flush(0xc0000d62c0)
	/Users/behrooz/go/src/github.com/meerkat/vendor/github.com/google/codesearch/index/write.go:210 +0x1f1
github.com/meerkat/index.(*indexer).Index(0xc00011e000, 0x13a56e0, 0xc001fb4060, 0x0, 0x0)
	/Users/behrooz/go/src/github.com/meerkat/index/indexer.go:239 +0x429
main.main.func1(0xc0002c4280, 0xc001e4e6d0, 0xc00011c000, 0x30, 0x13a25a0, 0xc00011e000, 0xc00039b800)
	/Users/behrooz/go/src/github.com/meerkat/main.go:88 +0x206
created by main.main
	/Users/behrooz/go/src/github.com/meerkat/main.go:76 +0x334
panic: runtime error: index out of range

goroutine 181 [running]:
github.com/meerkat/vendor/github.com/google/codesearch/index.sortPost(0xc01fab0000, 0x3b65, 0x800000)
	/Users/behrooz/go/src/github.com/meerkat/vendor/github.com/google/codesearch/index/write.go:628 +0x29f
github.com/meerkat/vendor/github.com/google/codesearch/index.(*IndexWriter).mergePost(0xc0011d2000, 0xc0000a6240)
	/Users/behrooz/go/src/github.com/meerkat/vendor/github.com/google/codesearch/index/write.go:291 +0x13c
github.com/meerkat/vendor/github.com/google/codesearch/index.(*IndexWriter).Flush(0xc0011d2000)
	/Users/behrooz/go/src/github.com/meerkat/vendor/github.com/google/codesearch/index/write.go:210 +0x1f1
github.com/meerkat/index.(*indexer).Index(0xc00011e000, 0x13a56e0, 0xc0003a7ae0, 0x0, 0x0)
	/Users/behrooz/go/src/github.com/meerkat/index/indexer.go:239 +0x429
main.main.func1(0xc0002c4280, 0xc001e4e6d0, 0xc00011c000, 0x30, 0x13a25a0, 0xc00011e000, 0xc00039b500)
	/Users/behrooz/go/src/github.com/meerkat/main.go:88 +0x206
created by main.main
	/Users/behrooz/go/src/github.com/meerkat/main.go:76 +0x334
```

This fix simply moves global unprotected vars to local func scope. We could alternatively include them in `IndexWriter` struct too. 