### PR TITLE
cindex: Log skipped files

### DIFF
--- a/cmd/cindex/cindex.go
+++ b/cmd/cindex/cindex.go
@@ -135,6 +135,7 @@ func main() {
 
 	ix := index.Create(file)
 	ix.Verbose = *verboseFlag
+	ix.LogSkip = true
 	ix.Zip = *zipFlag
 	ix.AddRoots(roots)
 	for _, root := range roots {


### PR DESCRIPTION
Files that can't be indexed for whatever reason have been silently ignored, leading to issues such as #26, #37, #80. Changing this behavior at least tells the user why files weren't added to the index.