### PR TITLE
index: fix repeated v2 index merge panic

### DIFF
--- a/index/merge.go
+++ b/index/merge.go
@@ -217,7 +217,7 @@ func Merge(dst, src1, src2 string) {
 			w.endTrigram()
 		} else {
 			w.trigram(r1.trigram)
-			if r1.trigram == ^uint32(0) {
+			if r1.trigram == invalidTrigram {
 				w.endTrigram()
 				break
 			}
@@ -299,7 +299,7 @@ type postMapReader struct {
 func (r *postMapReader) init(ix *Index, idmap []idrange) {
 	r.ix = ix
 	r.idmap = idmap
-	r.trigram = ^uint32(0)
+	r.trigram = invalidTrigram
 	r.nextBlock = 0
 	r.triNum = -1
 	r.load(true)
@@ -310,12 +310,12 @@ func (r *postMapReader) nextTrigram() {
 }
 
 func (r *postMapReader) load(force bool) {
-	if !force && r.trigram == ^uint32(0) {
+	if !force && r.trigram == invalidTrigram {
 		return
 	}
 	r.triNum++
 	if r.triNum >= r.ix.numPost {
-		r.trigram = ^uint32(0)
+		r.trigram = invalidTrigram
 		r.count = 0
 		r.fileid = -1
 		return

--- a/index/merge_test.go
+++ b/index/merge_test.go
@@ -76,6 +76,49 @@ func TestMerge(t *testing.T) {
 	checkPosting(t, ix3, "pot", 4, 5, 7)
 }
 
+func TestMergeRepeated(t *testing.T) {
+	old := writeVersion
+	defer func() {
+		writeVersion = old
+	}()
+	writeVersion = 2
+
+	tempIndex := func() string {
+		f, err := os.CreateTemp("", "index-test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		name := f.Name()
+		f.Close()
+		t.Cleanup(func() {
+			os.Remove(name)
+		})
+		return name
+	}
+
+	current := tempIndex()
+	buildIndex(current, mergePaths1, mergeFiles1)
+	wantPost := Open(current).numPost
+
+	for i := 1; i <= 4; i++ {
+		fresh := tempIndex()
+		next := tempIndex()
+		buildIndex(fresh, mergePaths1, mergeFiles1)
+		Merge(next, current, fresh)
+
+		ix := Open(next)
+		if err := ix.Check(); err != nil {
+			t.Fatalf("merge %d: Check: %v", i, err)
+		}
+		if ix.numPost != wantPost {
+			t.Fatalf("merge %d: numPost = %d, want %d", i, ix.numPost, wantPost)
+		}
+		checkFiles(t, ix, "/a/x", "/a/y", "/b/xx", "/b/xy", "/c/ab", "/c/de")
+
+		current = next
+	}
+}
+
 func checkFiles(t *testing.T, ix *Index, l ...string) {
 	t.Helper()
 	for i, s := range l {

--- a/index/write.go
+++ b/index/write.go
@@ -860,17 +860,26 @@ func (w *postDataWriter) trigram(t uint32) {
 	w.count = 0
 	w.t = t
 	w.lastID = -1
-	w.numTrigram++
-	w.out.WriteTrigram(w.t)
 }
 
 func (w *postDataWriter) fileid(id int) {
+	if w.count == 0 {
+		w.out.WriteTrigram(w.t)
+		w.numTrigram++
+	}
 	w.delta.Write(id - w.lastID)
 	w.lastID = id
 	w.count++
 }
 
 func (w *postDataWriter) endTrigram() {
+	if w.count == 0 {
+		if w.t != invalidTrigram {
+			return
+		}
+		w.out.WriteTrigram(w.t)
+		w.numTrigram++
+	}
 	w.delta.Write(0)
 	w.delta.Flush()
 	if w.postIndexFile == nil {


### PR DESCRIPTION
Fixes #100.

Repeated cindex runs against a v2 index could panic during merge with:

```text
panic: no progress
```

The merge reader used ^uint32(0) as its internal EOF marker, while the on-disk posting-list sentinel is invalidTrigram (0x00ffffff). As a result, merge treated the serialized sentinel as a normal trigram and then emitted another sentinel at EOF. Each successful merge accumulated another serialized sentinel and a later merge could stop making progress through the duplicate sentinel entries.

This change makes merge sentinel handling use invalidTrigram consistently. It also restores lazy posting-list writes so ordinary trigrams with no surviving file IDs are omitted, while the final sentinel is still emitted.

A regression test now repeatedly merges v2 indexes and checks that the merged index remains valid and does not grow extra posting entries.

Testing:

`go test ./...`

I also verified the issue reproduction manually on linux/amd64 with repeated no-argument cindex runs. The patched binary completed repeated reindexes, cindex-check -list passed and the final posting index contained exactly one 0xffffff sentinel with no non-increasing trigram entries.